### PR TITLE
Fix dialyzer warnings & error response on set

### DIFF
--- a/.dialyzer_ignore
+++ b/.dialyzer_ignore
@@ -1,0 +1,1 @@
+lib/cream/continuum.ex:42: Guard test _@1::'true' =:= 'false' can never succeed

--- a/lib/cream/cluster.ex
+++ b/lib/cream/cluster.ex
@@ -316,7 +316,7 @@ defmodule Cream.Cluster do
   %{"foo" => "bar", "one" => "one"} = get(pid, ["foo", "bar"])
   ```
   """
-  @spec get(t, key, Keyword.t) :: value
+  @spec get(t, key, Keyword.t) :: value | nil
   @spec get(t, keys, Keyword.t) :: items_map
   def get(cluster, key_or_keys, opts \\ [])
 

--- a/lib/cream/cluster.ex
+++ b/lib/cream/cluster.ex
@@ -54,9 +54,14 @@ defmodule Cream.Cluster do
   @type item :: {key, value}
 
   @typedoc """
+  Multiple items as a map.
+  """
+  @type items_map :: %{required(key) => value}
+
+  @typedoc """
   Multiple items as a list of tuples or a map.
   """
-  @type items :: [item] | [%{required(key) => value}]
+  @type items :: [item] | items_map
 
   @typedoc """
   Reason associated with an error.
@@ -286,8 +291,9 @@ defmodule Cream.Cluster do
   set(cluster, %{k1 => v1, k2 => v2}, ttl: 300)
   ```
   """
-  @spec set(t, item | items, Keyword.t) :: :ok | {:error, reason}
-  def set(cluster, item_or_items, opts \\ [])
+ @spec set(t, item, Keyword.t()) :: :ok | {:error, reason}
+ @spec set(t, items, Keyword.t()) :: %{required(key) => :ok | {:error, reason}}
+ def set(cluster, item_or_items, opts \\ [])
 
   def set(cluster, items, opts) when is_list(items) or is_map(items) do
     with_worker cluster, fn worker ->
@@ -311,7 +317,7 @@ defmodule Cream.Cluster do
   ```
   """
   @spec get(t, key, Keyword.t) :: value
-  @spec get(t, keys, Keyword.t) :: items
+  @spec get(t, keys, Keyword.t) :: items_map
   def get(cluster, key_or_keys, opts \\ [])
 
   def get(cluster, key, opts) when is_binary(key) do

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,8 @@ defmodule Cream.Mixfile do
          "README.md": [title: "README"],
          "CHANGELOG.md": [title: "CHANGELOG"]
        ]
-     ]
+     ],
+     dialyzer: [ignore_warnings: ".dialyzer_ignore"]
    ]
   end
 


### PR DESCRIPTION
Currently dialyzer causes some warnings (see below), so this fixes the warnings.

In addition, the error responses on failure in `set` are also fixed. It returns map that has item key and error string (e.g. `%{"some_key" => {:error, :closed}}`).


It also adds `.dialyzer_ignore` for an error that `Cream.Continum.alive?` (defined in `lib/cream/continuum.ex`) always returns `true`.

```
lib/cream/cluster.ex:301: The call maps:values('ok' | {'error',binary()}) breaks the contract (Map) -> Values when Map :: map(), Values :: [Value], Value :: term()
lib/cream/cluster.ex:319: The pattern #{Vkey@1:=Vvalue@1} can never match the type [{binary(),binary() | [any()] | map()} | #{binary()=>binary() | [any()] | map()}]
lib/cream/cluster.ex:361: The created fun has no local return
lib/cream/cluster.ex:363: The pattern #{Vkey@1:=Vvalue@1} can never match the type [{binary(),binary() | [any()] | map()} | #{binary()=>binary() | [any()] | map()}]
lib/cream/cluster.ex:365: The pattern #{} can never match the type [{binary(),binary() | [any()] | map()} | #{binary()=>binary() | [any()] | map()}]
lib/cream/cluster.ex:374: The created fun has no local return
lib/cream/cluster.ex:376: The created fun has no local return
lib/cream/cluster.ex:376: The call maps:is_key(_@1::any(),Vhits@1::[{binary(),binary() | [any()] | map()} | #{binary()=>binary() | [any()] | map()}]) will never return since it differs in the 2nd argument from the success typing arguments: (any(),map())
lib/cream/cluster.ex:379: The call maps:merge(Vhits@1::[{binary(),binary() | [any()] | map()} | #{binary()=>binary() | [any()] | map()}],Vmissing_hits@1::[{binary(),binary() | [any()] | map()} | #{binary()=>binary() | [any()] | map()}] | {binary(),binary() | [any()] | map()}) will never return since it differs in the 1st and 2nd argument from the success typing arguments: (map(),map())
lib/cream/continuum.ex:42: Guard test _@1::'true' =:= 'false' can never succeed
```