### PR TITLE
Bring key+attempt formatting in line with Dalli

### DIFF
--- a/lib/cream/continuum.ex
+++ b/lib/cream/continuum.ex
@@ -28,7 +28,7 @@ defmodule Cream.Continuum do
     hkey = if attempt == 0 do
       :erlang.crc32(key)
     else
-      :erlang.crc32("#{key}:#{attempt}")
+      :erlang.crc32("#{attempt}#{key}")
     end
 
     i = binary_search(continuum, hkey)


### PR DESCRIPTION
If the server for the key isn't found in the ring on the first iteration, then the new hash key in all subsequent attempts won't be generated in the same way as in the Dalli library.

This PR fixes it.

In Dalli it's `{attempt}{key}`, versus `{key}:{attempt}` (current, incompatible)

See:
https://github.com/petergoldstein/dalli/blob/b895ae1f99eafd542d34662c61ac627b344eed71/lib/dalli/ring.rb#L39